### PR TITLE
DEV - Removed the Ct dependance of ot

### DIFF
--- a/LSTM-hw.lua
+++ b/LSTM-hw.lua
@@ -58,7 +58,6 @@ c_t:annotate{graphAttributes = {color = 'green', fontcolor = 'green'}}
 local o_t = nn.Sigmoid()(nn.CAddTable()({
    nn.Linear(n_x, n_o)(x_t),
    nn.Linear(n_h, n_o)(h_tt),
-   nn.Linear(n_c, n_o)(c_t)
 }))
 o_t:annotate{graphAttributes = {color = 'blue', fontcolor = 'blue'}}
 


### PR DESCRIPTION
The use of `c[t-1]` in the calculation of `i[t]`, `f[t]`, `~c[t]` and the use of `c[t]` in `o[t]` are a variation of _LSTM_. Adding `c[t-1]` and `c[t]` to the linear gates is called _peepholes_, mentioned in [ref.](http://arxiv.org/pdf/1503.04069.pdf).
The _LSTM_ that we are making doesn't use `c[t-1]`, then we don't need `c[t]` for `o[t]`.
